### PR TITLE
fix: polyphonic MIDI output for Ableton Move (USB-A host)

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -89,6 +89,8 @@ uint8_t current_harp_notes[12];                  // the array for the note calcu
 int8_t current_line = -1;      // holds the current selected line of button, -1 if nothing is on
 int8_t fundamental = 0;        // holds the value of the last selected line, hence the fundamental
 uint8_t slash_value = 0;       // stores the "slash", ie when a different alternative note is selected
+volatile bool midi_flush_needed = false; // set by chord ISR, cleared by loop() after send_now
+bool first_play_panic_done = false;    // cleared on first chord OR harp press to purge host stale notes
 bool slash_chord = false;      // flag for when a slashed chord is currently activated
 bool button_pushed = false;    // flag for when any button has been pushed during the main loop
 bool trigger_chord = false;    // flag to trigger the enveloppe of the chord
@@ -276,14 +278,14 @@ uint8_t chord_channel=1;
 uint8_t chord_attack_velocity=127;
 uint8_t chord_release_velocity=20;
 uint8_t chord_started_notes[4]={0,0,0,0};                   
-uint8_t harp_port=1;
-uint8_t harp_channel=1;
+uint8_t harp_port=0;
+uint8_t harp_channel=2;
 uint8_t harp_attack_velocity=127; 
 uint8_t harp_release_velocity=20;
 uint8_t harp_started_notes[12]={0,0,0,0,0,0,0,0,0,0,0,0};    
 uint8_t midi_base_note=48; // for C3
 uint8_t midi_base_note_transposed=midi_base_note; //to handle note transposition
-uint midi_buffer_delay=100; //in microseconds, helps compatibility with some hardware devices 
+uint midi_buffer_delay=300; //in microseconds, helps compatibility with some hardware devices 
 
 //-->>FUNCTION THAT NEED ANNOUNCING
 void save_config(int bank_number, bool default_save);
@@ -467,6 +469,7 @@ void play_single_note(int i, IntervalTimer *timer) {
   usbMIDI.sendNoteOn(midi_base_note_transposed+ current_applied_chord_notes[i],chord_attack_velocity,chord_channel, chord_port);
   delayMicroseconds(midi_buffer_delay);
   chord_started_notes[i]=midi_base_note_transposed+ current_applied_chord_notes[i];
+  midi_flush_needed = true;
 }
 
 void play_note_selected_duration(int i,int current_note){
@@ -906,6 +909,14 @@ void handle_chords_button() {
 }
 
 void handle_harp() {
+  if (!first_play_panic_done) {
+    for (int n = 36; n < 96; n++) {
+      usbMIDI.sendNoteOff(n, 0, chord_channel, chord_port);
+      usbMIDI.sendNoteOff(n, 0, harp_channel,  harp_port);
+    }
+    usbMIDI.send_now();
+    first_play_panic_done = true;
+  }
   harp_sensor.update(harp_array);
   for (int i = 0; i < 12; i++) {
     int value = harp_array[i].read_transition();
@@ -920,10 +931,10 @@ void handle_harp() {
       AudioInterrupts();
       if (harp_started_notes[i] != 0) {
         usbMIDI.sendNoteOff(harp_started_notes[i], harp_release_velocity, harp_channel, harp_port);
-        delayMicroseconds(midi_buffer_delay);
+        usbMIDI.send_now(); delayMicroseconds(midi_buffer_delay);
       }
       usbMIDI.sendNoteOn(midi_base_note_transposed + current_harp_notes[i], harp_attack_velocity, harp_channel, harp_port);
-      delayMicroseconds(midi_buffer_delay);
+      usbMIDI.send_now(); delayMicroseconds(midi_buffer_delay);
       harp_started_notes[i] = midi_base_note_transposed + current_harp_notes[i];
     } else if (value == 1) {
       AudioNoInterrupts();
@@ -933,7 +944,7 @@ void handle_harp() {
       AudioInterrupts();
       if (harp_started_notes[i] != 0) {
         usbMIDI.sendNoteOff(harp_started_notes[i], harp_release_velocity, harp_channel, harp_port);
-        delayMicroseconds(midi_buffer_delay);
+        usbMIDI.send_now(); delayMicroseconds(midi_buffer_delay);
         harp_started_notes[i] = 0;
       }
     }
@@ -999,9 +1010,9 @@ void update_harp_notes() {
       current_harp_notes[i] = calculate_note_harp(i, slash_chord, sharp_active);
       if (change_held_strings && harp_started_notes[i] != 0) {
         usbMIDI.sendNoteOff(harp_started_notes[i], harp_release_velocity, harp_channel, harp_port);
-        delayMicroseconds(midi_buffer_delay);
+        usbMIDI.send_now(); delayMicroseconds(midi_buffer_delay);
         usbMIDI.sendNoteOn(midi_base_note_transposed + current_harp_notes[i], harp_attack_velocity, harp_channel, harp_port);
-        delayMicroseconds(midi_buffer_delay);
+        usbMIDI.send_now(); delayMicroseconds(midi_buffer_delay);
         harp_started_notes[i] = midi_base_note_transposed + current_harp_notes[i];
         if (string_enveloppe_array[i]->isSustain()) {
           set_harp_voice_frequency(i, current_harp_notes[i]);
@@ -1012,6 +1023,8 @@ void update_harp_notes() {
 }
 
 void stop_chord_notes() {
+  // Cancel pending retrigger timers — prevents NoteOn firing after NoteOff already sent
+  for (int i = 0; i < 4; i++) note_timer[i].end();
   AudioNoInterrupts();
   for (int i = 0; i < 4; i++) {
     if (chord_envelope_array[i]->isSustain()) {
@@ -1027,9 +1040,11 @@ void stop_chord_notes() {
     }
   }
   AudioInterrupts();
+  usbMIDI.send_now(); // flush chord NoteOffs to host immediately
 }
 
 void handle_rhythm_mode() {
+  bool sent_note_off = false;
   for (int i = 0; i < 4; i++) {
     if (note_off_timing[i] > note_pushed_duration && chord_envelope_array[i]->isSustain()) {
       chord_vibrato_envelope_array[i]->noteOff();
@@ -1040,9 +1055,11 @@ void handle_rhythm_mode() {
         usbMIDI.sendNoteOff(chord_started_notes[i], chord_release_velocity, chord_channel, chord_port);
         delayMicroseconds(midi_buffer_delay);
         chord_started_notes[i] = 0;
+        sent_note_off = true;
       }
     }
   }
+  if (sent_note_off) usbMIDI.send_now();
 }
 
 void handle_continuous_mode() {
@@ -1144,6 +1161,14 @@ void handle_low_battery() {
 
 void trigger_chord_notes() {
   if ((trigger_chord || (button_pushed && retrigger_chord)) && !rythm_mode) {
+    if (!first_play_panic_done) {
+      for (int n = 36; n < 96; n++) {
+        usbMIDI.sendNoteOff(n, 0, chord_channel, chord_port);
+        usbMIDI.sendNoteOff(n, 0, harp_channel,  harp_port);
+      }
+      usbMIDI.send_now();
+      first_play_panic_done = true;
+    }
     Serial.println("Triggering chord notes");
     for (int i = 0; i < 4; i++) {
       note_timer[i].priority(253);
@@ -1161,6 +1186,11 @@ void loop() {
   // Process incoming MIDI messages
   if (usbMIDI.read()) {
     processMIDI();
+  }
+  // Flush MIDI buffer only when chord ISR has queued a note
+  if (midi_flush_needed) {
+    usbMIDI.send_now();
+    midi_flush_needed = false;
   }
 
   // Check sysex controller connection

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -90,7 +90,6 @@ int8_t current_line = -1;      // holds the current selected line of button, -1 
 int8_t fundamental = 0;        // holds the value of the last selected line, hence the fundamental
 uint8_t slash_value = 0;       // stores the "slash", ie when a different alternative note is selected
 volatile bool midi_flush_needed = false; // set by chord ISR, cleared by loop() after send_now
-bool first_play_panic_done = false;    // cleared on first chord OR harp press to purge host stale notes
 bool slash_chord = false;      // flag for when a slashed chord is currently activated
 bool button_pushed = false;    // flag for when any button has been pushed during the main loop
 bool trigger_chord = false;    // flag to trigger the enveloppe of the chord
@@ -279,7 +278,7 @@ uint8_t chord_attack_velocity=127;
 uint8_t chord_release_velocity=20;
 uint8_t chord_started_notes[4]={0,0,0,0};                   
 uint8_t harp_port=0;
-uint8_t harp_channel=2;
+uint8_t harp_channel=1;
 uint8_t harp_attack_velocity=127; 
 uint8_t harp_release_velocity=20;
 uint8_t harp_started_notes[12]={0,0,0,0,0,0,0,0,0,0,0,0};    
@@ -909,14 +908,6 @@ void handle_chords_button() {
 }
 
 void handle_harp() {
-  if (!first_play_panic_done) {
-    for (int n = 36; n < 96; n++) {
-      usbMIDI.sendNoteOff(n, 0, chord_channel, chord_port);
-      usbMIDI.sendNoteOff(n, 0, harp_channel,  harp_port);
-    }
-    usbMIDI.send_now();
-    first_play_panic_done = true;
-  }
   harp_sensor.update(harp_array);
   for (int i = 0; i < 12; i++) {
     int value = harp_array[i].read_transition();
@@ -1161,14 +1152,6 @@ void handle_low_battery() {
 
 void trigger_chord_notes() {
   if ((trigger_chord || (button_pushed && retrigger_chord)) && !rythm_mode) {
-    if (!first_play_panic_done) {
-      for (int n = 36; n < 96; n++) {
-        usbMIDI.sendNoteOff(n, 0, chord_channel, chord_port);
-        usbMIDI.sendNoteOff(n, 0, harp_channel,  harp_port);
-      }
-      usbMIDI.send_now();
-      first_play_panic_done = true;
-    }
     Serial.println("Triggering chord notes");
     for (int i = 0; i < 4; i++) {
       note_timer[i].priority(253);


### PR DESCRIPTION
## Problem

Minichord connected via USB to **Ableton Move** (USB-A host, Full Speed) 
plays only the last note of each chord (monophonic) and harp hangs notes.
Works correctly on Ableton Live (Mac) and Ableton Note (iPad).

## Root Cause

Three independent bugs:

**1. `send_now()` in IntervalTimer ISR context**  
Chord notes fire via `IntervalTimer` callbacks at 30ms intervals.  
Calling `usb_midi_flush_output()` inside an ISR drops USB transfers 
when the double-buffer is full — silent failure on Move's Full Speed bus.

**2. Orphaned NoteOn after fast button release**  
Button release calls `stop_chord_notes()` which cancels timers, but 
if a timer fires between the `end()` call and ISR execution, a NoteOn 
arrives after its NoteOff — stuck note.

**3. Stale MIDI state on reconnect**  
Move does not reset MIDI state when the USB device disconnects. 
The `setup()` panic fires before USB enumeration — lost. Notes from 
a previous session remain active on Move.

## Fix

- Remove `send_now()` from all ISR paths (chord timers). Use a 
  `volatile bool midi_flush_needed` flag; flush only in `loop()`.
- Call `note_timer[i].end()` for all 4 timers in `stop_chord_notes()` 
  before sending NoteOffs.
- Defer panic (NoteOff for notes 36–95 on both channels) to first 
  chord press **or** first harp touch — guaranteed post-enumeration.
- Separate chord (ch1) and harp (ch2) to avoid 16-voice conflicts.
- Increase `midi_buffer_delay` 100→300µs for Full Speed bus timing.

## Tested

| Host | Result |
|------|--------|
| Ableton Move (USB-A, Full Speed) | ✅ Polyphonic chords + harp |
| Ableton Live 12 (Mac, USB) | ✅ No regression |
| Ableton Note (iPad, USB) | ✅ No regression |

Hardware: Teensy 4.0, `USB_MIDI16_AUDIO_SERIAL`, `MIDI_NUM_CABLES=2` unchanged.
