### PR TITLE
Fix octave decoding in the chord glide path

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -506,10 +506,10 @@ void calculate_ws_array() {
 void set_chord_voice_frequency(uint8_t i, uint16_t current_note) {
   float note_freq = pow(2,chord_octave_change)*c_frequency/8 * pow(2, (current_note+transpose_semitones) / 12.0); //down one octave to let more possibilities with the shuffling array
   if(glide_length>0){
-        //ok so first we need to set the "middle note". Keep in mind that the signal will be +/-1 and will go +/- 1 octave
+        //ok so first we need to set the "middle note". Keep in mind that the signal will be +/-1 and will go +/- 2 octaves (frequencyModulation(2), hence the /24.0 below)
     //let's do a trick to select a middle note: get the level (relative to the C) and the note and do a modulo 
     int note_level=12*chord_octave_change-3*12+current_note+transpose_semitones;
-    int base_octave =chord_octave_change-2+(chord_shuffling_array[chord_shuffling_selection][i])/12;
+    int base_octave =chord_octave_change-2+(chord_shuffling_array[chord_shuffling_selection][i])/10;
     int middle_note=base_octave*12+transpose_semitones; 
     int note_delta=note_level-middle_note;
     float middle_freq=c_frequency*pow(2,middle_note/12.0);


### PR DESCRIPTION
## The bug

The shuffling array is base-10 encoded. The comment above `chord_shuffling_array`
says so:

```cpp
//the /10 number indicates the octave
```

and both `calculate_note_chord` and `calculate_note_harp` read it that way, with
`12 * int(level / 10)`.

The glide path in `set_chord_voice_frequency` divides by 12 instead:

```cpp
int base_octave = chord_octave_change - 2 + (chord_shuffling_array[chord_shuffling_selection][i]) / 12;
```

So level `10` resolves to octave 0 rather than 1, and level `20` to octave 1
rather than 2.

## This is currently inaudible

Worth saying up front, because it explains why it has gone unnoticed and why
this is not urgent.

`base_octave` decides where the oscillator sits; `note_delta` carries the
remainder and the DC offset restores it, so the pitch comes out correct. The
glide is unaffected too in normal playing: the DC ramps from its previous value
to the new one, so what you hear is the *change* in `note_delta` from one chord
to the next. The `/12` error adds a constant offset per row and voice, and a
constant cancels in a difference. Playing C then G sweeps the same 7 semitones
on every shuffling row either way.

## What it does cost

Headroom. `frequencyModulation(2)` is plus or minus two octaves, which is what
the `/24.0` normalises against, so `note_delta` saturates past 24 semitones.
Across every combination of chord type, key, octave setting and transposition:

| | worst \|note_delta\| |
|---|---|
| `/10` (correct) | 12 semitones |
| `/12` (current) | 23 semitones |

Nothing clips today. But the margin is one semitone instead of twelve, so
anything that adds pitch to a chord voice pushes it over, and past 24 the DC
clamps and the pitch really is wrong.

I ran into this while adding a chord inversion parameter, which raises voices by
up to an octave. On the current code 2925 voice configurations saturate; with
`/10`, none do.

`glide-octave-check.py` reproduces both numbers.

## Also

The comment above that block says the signal "will go +/- 1 octave".
`frequencyModulation(2)` and the `/24.0` normalisation are both plus or minus
two octaves. Corrected in passing.

## Scope

One character in `main.cpp`, plus the comment. No parameters, no generated
files, no regeneration needed.

## Testing

- Verified both encodings against every voicing, chord type, key, octave setting
  and transposition, with and without an added octave on the voices.
- Hardware: no audible change