### PR TITLE
Add a control command to load a bank

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -390,6 +390,15 @@ void control_command(uint8_t command, uint8_t parameter) {
     current_bank_number = parameter;
     save_config(parameter, true);
     break;
+  case 4: // loading a bank, so a remote can read every preset in turn
+    if (parameter < preset_number) {
+      Serial.print("Loading bank: ");
+      Serial.println(parameter);
+      current_bank_number = parameter;
+      load_config(current_bank_number);
+      set_led_color(bank_led_hue, 1.0, 1 - led_attenuation);
+    }
+    break;
 
   default:
     break;


### PR DESCRIPTION
Reworked from #77, which I closed. Your feedback there was that complex
operations should live on the remote side and that a long sysex buffer made you
nervous. Both were right, and this is what is left of that PR once the logic
moves off the device: nine lines and no buffer change.

## What is missing today

The remote can already read the current parameters (command 0), save them to a
bank (command 2), reset a bank (command 3) and wipe memory (command 1). What it
cannot do is choose which bank is loaded. Only the physical preset buttons do
that.

So a remote can read one bank, the one that happens to be selected, and no
others. Anything that needs to see the whole device is impossible without
someone standing there pressing buttons.

## The change

```c
case 4: // loading a bank, so a remote can read every preset in turn
  if (parameter < preset_number) {
    current_bank_number = parameter;
    load_config(current_bank_number);
    set_led_color(bank_led_hue, 1.0, 1 - led_attenuation);
  }
  break;
```

## What it enables, entirely on the remote side

**Backing up the whole device** becomes twelve select-then-read round trips: send
command 4, send command 0, keep the 512-byte report, repeat. The largest message
stays the one you already send.

**Restoring** needs nothing new at all. For each bank: select it, write the
parameters individually with the existing per-parameter sysex, then command 2 to
commit. That is exactly what the editor already does for a single preset, just
twelve times.

So there is no bulk transfer message, no second format alongside the existing
one, and no reason to grow the sysex buffer past 290. It is also naturally
sequential and acknowledged, which is what you suggested in #77 instead of the
long buffer.

I have this working against Sound Lab, where whole-device backup, restore,
reordering and bulk edits are all built on this one command and nothing else.

## Notes

The bounds check keeps a malformed message from loading a bank that does not
exist. The LED refresh means the device visibly follows along as a remote walks
the banks, which doubles as feedback that something is happening.

`load_config` already handles muting and note-off internally, so nothing extra
is needed around the call.

## Testing

- Hardware: Remote can select each bank and read it back,
  and the device is left on the bank it started on
