### PR TITLE
Let a potentiometer claim the modifier button

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -95,6 +95,12 @@ bool button_pushed = false;    // flag for when any button has been pushed durin
 bool trigger_chord = false;    // flag to trigger the enveloppe of the chord
 bool sharp_active = false;     // flag for when the sharp is active
 bool flat_button_modifier= false; //flag to set the modifier to flat instead of sharp
+// The modifier button both sharpens the chord and selects the potentiometers'
+// alternate targets, so reaching for an alternate setting while playing would
+// sharpen whatever is sounding. Once a potentiometer actually moves under the
+// held modifier, the modifier is taken to mean "alternate" for the rest of that
+// hold, and the sharpening is dropped.
+bool modifier_claimed_by_pot = false;
 bool continuous_chord = false; // wether the chord is held continuously. Controlled by the "hold" button
 bool rythm_mode = false;
 bool barry_harris_mode = false;
@@ -889,7 +895,7 @@ void handle_chords_button() {
   if (sharp_transition > 1 && current_line != -1) {
     button_pushed = true;
   }
-  sharp_active = chord_matrix_array[0].read_value();
+  sharp_active = chord_matrix_array[0].read_value() && !modifier_claimed_by_pot;
 
   for (int i = 1; i < 22; i++) {
     int value = chord_matrix_array[i].read_transition();
@@ -1204,9 +1210,19 @@ void loop() {
 
   // Handle potentiometer updates
   bool alternate = chord_matrix_array[0].read_value();
-  flag_save_needed |= chord_pot.update_parameter(alternate);
-  flag_save_needed |= harp_pot.update_parameter(alternate);
-  flag_save_needed |= mod_pot.update_parameter(alternate);
+  bool pot_moved = false;
+  pot_moved |= chord_pot.update_parameter(alternate);
+  pot_moved |= harp_pot.update_parameter(alternate);
+  pot_moved |= mod_pot.update_parameter(alternate);
+  flag_save_needed |= pot_moved;
+
+  if (!alternate) {
+    modifier_claimed_by_pot = false;
+  } else if (pot_moved && !modifier_claimed_by_pot) {
+    modifier_claimed_by_pot = true;
+    // a chord is already sounding sharpened, so recalculate it without
+    if (current_line != -1) button_pushed = true;
+  }
 
   // Handle continuous mode logic
   if (!continuous_chord && !rythm_mode) {


### PR DESCRIPTION
## The problem

The modifier button does two jobs from the same read:

```c
sharp_active = chord_matrix_array[0].read_value();      // sharpens the chord
bool alternate = chord_matrix_array[0].read_value();    // selects alternate pot targets
```

So reaching for an alternate potentiometer setting while a chord is sounding
sharpens it. There is no way to get at the alternate targets without also
altering what you are playing.

There is a third consequence that makes it more noticeable than it sounds.
`handle_chords_button` treats the modifier press as a chord event:

```c
int sharp_transition = chord_matrix_array[0].read_transition();
if (sharp_transition > 1 && current_line != -1) {
  button_pushed = true;
}
```

so pressing the modifier with a chord held recalculates that chord, sharp. It is
not only the next chord that changes, it is the one already ringing.

## The change

When a potentiometer actually moves while the modifier is held, the modifier is
taken to mean "alternate" for the rest of that hold: the sharpening is dropped,
and a chord that is already sounding is recalculated without it. Releasing the
modifier clears the claim, so the next press sharpens as before.

`update_parameter` already returns whether a value changed, so detecting the
movement needed no new plumbing — the return value was being folded straight
into `flag_save_needed` and is now also read on its own.

## What it does to the existing gestures

Walking a state machine through the cases that matter, one column per loop pass:

```
play a sharpened chord, no pot          sharp sharp sharp sharp sharp sharp
hold chord, press modifier, turn knob   sharp sharp   -     -     -     -
modifier + knob with no chord held      sharp   -     -     -
knob, release, then sharpen again         -     -     -   sharp sharp
knob moved without the modifier           -     -   sharp sharp
```

Ordinary sharpening is untouched. Moving a potentiometer without the modifier
claims nothing.

## What it does not fix

There is a short window before the knob moves where the modifier still reads as
sharp — the second row above, two passes of `sharp` before the claim engages.
That is the modifier being pressed before you have touched the knob, and I do
not think it can be removed without either delaying the sharpening, which would
hurt it as a musical gesture, or a second modifier button, which does not exist.
At loop rate it is a few milliseconds.

## Why I ran into it

I have chord inversion and chord spacing in review, and both are things you would
want on a knob while playing. Assigning either to a potentiometer's main function
works fine; assigning them to an alternate target does not, for the reason above.
That is what surfaced it, but the problem is not specific to those parameters —
it applies to every alternate assignment.

Worth saying plainly that this button is carrying three jobs, and this only
separates two of them. If it ever seems worth a bigger rethink I would be glad to
help, but this seemed like the smallest change that makes alternate targets
usable while playing.

## Scope

Twenty lines in `main.cpp`. No parameters, no generated files, no `version_ID`
bump.

## Testing

- State machine walked through the gesture sequences above.
- Hardware: Hold a chord, reach for an alternate setting, the
  chord does not sharpen; ordinary sharpening still works
